### PR TITLE
[fix] Use KeyVaukt instead of .env

### DIFF
--- a/src/api/AutonomousCars.Api/AutonomousCars.Api.csproj
+++ b/src/api/AutonomousCars.Api/AutonomousCars.Api.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0-beta.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0-beta.2" />
     <PackageReference Include="GeoJSON.Text" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="MQTTnet" Version="4.3.1.873" />

--- a/src/api/AutonomousCars.Api/Controllers/ListingDevicesController.cs
+++ b/src/api/AutonomousCars.Api/Controllers/ListingDevicesController.cs
@@ -25,15 +25,26 @@ public class ListingDevicesController : Controller
     [HttpGet("getAllDevices")]
     public async Task<IActionResult> GetAllDevices()
     {
-        string subscriptionId = _mqttNamespaceOptions.SubscriptionId ?? throw new MissingSettingException($"{nameof(MqttNamespaceOptions)}.{nameof(MqttNamespaceOptions.SubscriptionId)}");
-        string resourceGroupName = _mqttNamespaceOptions.ResourceGroupName ?? throw new MissingSettingException($"{nameof(MqttNamespaceOptions)}.{nameof(MqttNamespaceOptions.ResourceGroupName)}");
-        string namespaceName =  _mqttNamespaceOptions.NamespaceName ?? throw new MissingSettingException($"{nameof(MqttNamespaceOptions)}.{nameof(MqttNamespaceOptions.NamespaceName)}");
+        MqttNamespaceOptions? mqttNamespaceOptions = MqttSettings.MqttNamespaceOptions;
 
-        var response = new
+        if (mqttNamespaceOptions != null)
         {
-            Status = "Success",
-            DeviceNames = await _mqttDevices.GetDeviceNames(subscriptionId, resourceGroupName, namespaceName)
-        };
-        return Ok(response);
+            var response = new
+            {
+                Status = "Success",
+                DeviceNames = await _mqttDevices.GetDeviceNames(mqttNamespaceOptions)
+            };
+            return Ok(response);
+        }
+        else
+        {
+            var errorResponse = new
+            {
+                Status = "Error",
+                Message = "Issue of configuration.",
+            };
+            return BadRequest(errorResponse);
+        }
+
     }
 }

--- a/src/api/AutonomousCars.Api/Device/Services/IMqttDevices.cs
+++ b/src/api/AutonomousCars.Api/Device/Services/IMqttDevices.cs
@@ -1,6 +1,8 @@
+using AutonomousCars.Api.Models.Options;
+
 namespace AutonomousCars.Api.Device.Services;
 
 public interface IMqttDevices
 {
-    public Task<List<String>> GetDeviceNames(string subscriptionId, string resourceGroupName, string namespaceName);
+    public Task<List<String>> GetDeviceNames(MqttNamespaceOptions mqttNamespaceOptions);
 }

--- a/src/api/AutonomousCars.Api/Device/Services/MqttDevices.cs
+++ b/src/api/AutonomousCars.Api/Device/Services/MqttDevices.cs
@@ -10,13 +10,13 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.EventGrid;
 public class MqttDevices : IMqttDevices
 {
-    public async Task<List<String>> GetDeviceNames(string subscriptionId, string resourceGroupName, string namespaceName)
+    public async Task<List<String>> GetDeviceNames(MqttNamespaceOptions mqttNamespaceOptions)
     {
         TokenCredential cred = new DefaultAzureCredential();
         ArmClient client = new ArmClient(cred);
+
         
-        
-        ResourceIdentifier eventGridNamespaceResourceId = EventGridNamespaceResource.CreateResourceIdentifier(subscriptionId, resourceGroupName, namespaceName);
+        ResourceIdentifier eventGridNamespaceResourceId = EventGridNamespaceResource.CreateResourceIdentifier(mqttNamespaceOptions.SubscriptionId, mqttNamespaceOptions.ResourceGroupName, mqttNamespaceOptions.Namespace);
         EventGridNamespaceResource eventGridNamespace = client.GetEventGridNamespaceResource(eventGridNamespaceResourceId);
         
         EventGridNamespaceClientCollection collection = eventGridNamespace.GetEventGridNamespaceClients();
@@ -29,7 +29,6 @@ public class MqttDevices : IMqttDevices
             resourceData.Attributes.TryGetValue("type", out var typeValue);
             if ("\"vehicle\"".Equals(typeValue?.ToString()))
             {
-                Console.WriteLine($"Succeeded on id: {resourceData.Name}");
                 deviceNames.Add(resourceData.Name);
             }
         }

--- a/src/api/AutonomousCars.Api/Itinerary/Services/AzureMapsItineraryService.cs
+++ b/src/api/AutonomousCars.Api/Itinerary/Services/AzureMapsItineraryService.cs
@@ -1,11 +1,13 @@
 namespace AutonomousCars.Api.Itinerary.Services;
 
+using AutonomousCars.Api.Models.Options;
 using GeoJSON.Text.Geometry;
 using GeoJSON.Text.Feature;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Client.Extensions;
 using Utils;
+
 
 public class AzureMapsItineraryService : IItineraryService
 {
@@ -63,33 +65,40 @@ public class AzureMapsItineraryService : IItineraryService
         };
         return new Feature<LineString>(positionsLineString, properties);
     }
-    
     public async Task SendRequest(CancellationToken stoppingToken,  Feature<LineString> geospatialFeature, bool isStatusRequest)
     {
-        var cs = MqttConnectionSettings.CreateFromEnvVars(_configuration.GetValue<string>("envFile"));
-        _logger.LogInformation("Connecting to {cs}", cs);
-
-        var mqttClient = new MqttFactory().CreateMqttClient(MqttNetTraceLogger.CreateTraceLogger());
-        mqttClient.DisconnectedAsync += e =>
+        
+        var cs = MqttSettings.MqttConnectionSettings;
+        if (cs != null)
         {
-            _logger.LogInformation("Mqtt client disconnected with reason: {e}", e.Reason);
-            return Task.CompletedTask;
-        };
+            _logger.LogInformation("Connecting to {cs}", cs);
 
-        var connAck = await mqttClient.ConnectAsync(new MqttClientOptionsBuilder().WithConnectionSettings(cs).Build(), stoppingToken);
-        _logger.LogInformation("Client {ClientId} connected: {ResultCode}", mqttClient.Options.ClientId, connAck.ResultCode);
+            var mqttClient = new MqttFactory().CreateMqttClient(MqttNetTraceLogger.CreateTraceLogger());
+            mqttClient.DisconnectedAsync += e =>
+            {
+                _logger.LogInformation("Mqtt client disconnected with reason: {e}", e.Reason);
+                return Task.CompletedTask;
+            };
 
-        var properties = geospatialFeature.Properties;
-        var carId = GeoJsonUtils.GetStringProperty(properties, IdPropName);
-        if (carId != null)
-        {
-            ItineraryTelemetryProducer telemetry = new(mqttClient, carId);
-            MqttClientPublishResult pubAck = await telemetry.SendTelemetryAsync(geospatialFeature, stoppingToken);
-            _logger.LogInformation("Message published with PUBACK {code} and mid {mid}", pubAck.ReasonCode, pubAck.PacketIdentifier);
-        } else
-        {
-            _logger.LogError("Failure of the Deserialization");
+            var connAck = await mqttClient.ConnectAsync(new MqttClientOptionsBuilder().WithConnectionSettings(cs).Build(), stoppingToken);
+            _logger.LogInformation("Client {ClientId} connected: {ResultCode}", mqttClient.Options.ClientId, connAck.ResultCode);
+
+            var properties = geospatialFeature.Properties;
+            var carId = GeoJsonUtils.GetStringProperty(properties, IdPropName);
+            if (carId != null)
+            {
+                ItineraryTelemetryProducer telemetry = new(mqttClient, carId);
+                MqttClientPublishResult pubAck = await telemetry.SendTelemetryAsync(geospatialFeature, stoppingToken);
+                _logger.LogInformation("Message published with PUBACK {code} and mid {mid}", pubAck.ReasonCode, pubAck.PacketIdentifier);
+            } else
+            {
+                _logger.LogError("Failure of the Deserialization");
+            }
+            await mqttClient.DisconnectAsync();
         }
-        await mqttClient.DisconnectAsync();
+        else
+        {
+            _logger.LogError("Error to open the connexion");
+        }
     }
 }   

--- a/src/api/AutonomousCars.Api/Models/Options/KeyVaultOptions.cs
+++ b/src/api/AutonomousCars.Api/Models/Options/KeyVaultOptions.cs
@@ -1,0 +1,6 @@
+namespace AutonomousCars.Api.Models.Options;
+
+public class KeyVaultOptions
+{
+    public required string KeyVaultName { get; set; }
+}

--- a/src/api/AutonomousCars.Api/Models/Options/MqttNamespaceOptions.cs
+++ b/src/api/AutonomousCars.Api/Models/Options/MqttNamespaceOptions.cs
@@ -2,7 +2,14 @@ namespace AutonomousCars.Api.Models.Options;
 
 public class MqttNamespaceOptions
 {
-    public required string SubscriptionId { get; set; }
-    public required string ResourceGroupName { get; set; }
-    public required string NamespaceName { get; set; }
+    public string SubscriptionId { get; }
+    public string ResourceGroupName { get; }
+    public string Namespace { get; }
+
+    public MqttNamespaceOptions(string subscriptionId, string resourceGroupName, string namespaceName)
+    {
+        SubscriptionId = subscriptionId;
+        ResourceGroupName = resourceGroupName;
+        Namespace = namespaceName;
+    }
 }

--- a/src/api/AutonomousCars.Api/Models/Options/MqttSettings.cs
+++ b/src/api/AutonomousCars.Api/Models/Options/MqttSettings.cs
@@ -1,0 +1,79 @@
+namespace AutonomousCars.Api.Models.Options;
+
+using MQTTnet.Client.Extensions;
+using System;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using System.Text.RegularExpressions;
+using System.IO;
+
+public static class MqttSettings
+{
+    public static MqttConnectionSettings? MqttConnectionSettings;
+
+    public static MqttNamespaceOptions? MqttNamespaceOptions { get; set; }
+    
+    public static async Task InitMqttSettings(KeyVaultOptions? keyVaultOptions)
+    {
+        if (keyVaultOptions != null)
+        {
+            string keyVaultName = keyVaultOptions.KeyVaultName;
+            var kvUri = "https://" + keyVaultName + ".vault.azure.net";
+
+            var secretClient = new SecretClient(new Uri(kvUri), new DefaultAzureCredential());
+
+            var backClientIdSecret = await secretClient.GetSecretAsync("BackClientId");
+            var backMqttUsernameSecret = await secretClient.GetSecretAsync("BackMqttUsername");
+            var backMqttCleanSessionSecret = await secretClient.GetSecretAsync("BackMqttCleanSession");
+            var backMqttUseTlsSecret = await secretClient.GetSecretAsync("BackMqttUseTLS");
+            var backMqttTcpPortSecret = await secretClient.GetSecretAsync("BackMqttTcpPort");
+            var backMqttHostNameSecret = await secretClient.GetSecretAsync("BackMqttHostName");
+            var backSubscriptionIdSecret = await secretClient.GetSecretAsync("BackSubscriptionId");
+            var backResourceGroupNameSecret = await secretClient.GetSecretAsync("BackResourceGroupName");
+            var backNamespaceSecret = await secretClient.GetSecretAsync("BackNamespace");
+            MqttNamespaceOptions = new MqttNamespaceOptions(backSubscriptionIdSecret.Value.Value, backResourceGroupNameSecret.Value.Value, backNamespaceSecret.Value.Value);
+            
+            var response = await secretClient.GetSecretAsync("Back");
+            var keyVaultSecret = response?.Value;
+            if (keyVaultSecret != null)
+            {
+                ExtractPrivateKeyAndCertificate(keyVaultSecret.Value);
+            }
+
+            string directoryPath = AppDomain.CurrentDomain.BaseDirectory;
+            string privateKeyPath = Path.Combine(directoryPath, "back.key");
+            string certificatePath = Path.Combine(directoryPath, "back.pem");
+
+            MqttConnectionSettings = MqttConnectionSettings.CreateFromValues(
+                backMqttHostNameSecret.Value.Value,
+                backMqttUsernameSecret.Value.Value,
+                backClientIdSecret.Value.Value,
+                certificatePath,
+                privateKeyPath,
+                bool.Parse(backMqttCleanSessionSecret.Value.Value),
+                bool.Parse(backMqttUseTlsSecret.Value.Value),
+                int.Parse(backMqttTcpPortSecret.Value.Value));
+        }
+    }
+    
+    private static void ExtractPrivateKeyAndCertificate(string input)
+    {
+        Regex privateKeyRegex = new Regex(@"(-----BEGIN PRIVATE KEY-----.*?-----END PRIVATE KEY-----)", RegexOptions.Singleline);
+        Regex certificateRegex = new Regex(@"(-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----)", RegexOptions.Singleline);
+
+        Match privateKeyMatch = privateKeyRegex.Match(input);
+        string directoryPath = AppDomain.CurrentDomain.BaseDirectory;
+        if (privateKeyMatch.Success)
+        {
+            string privateKeyWithHeader = privateKeyMatch.Groups[1].Value.Trim();
+            File.WriteAllText(directoryPath+"back.key", privateKeyWithHeader);
+        }
+        
+        Match certificateMatch = certificateRegex.Match(input);
+        if (certificateMatch.Success)
+        {
+            string certificateWithHeader = certificateMatch.Groups[1].Value.Trim();
+            File.WriteAllText(directoryPath+"back.pem", certificateWithHeader);
+        }
+    }
+}

--- a/src/mqttclients/MqttConnectionSettings.cs
+++ b/src/mqttclients/MqttConnectionSettings.cs
@@ -49,6 +49,26 @@ public class MqttConnectionSettings
 
     public static MqttConnectionSettings FromConnectionString(string cs) => ParseConnectionString(cs);
 
+    public static MqttConnectionSettings CreateFromValues(string hostname, string username, string clientId, string certFile, string keyFile, bool cleanSession, bool useTLS, int tcpPort)
+    {
+        return new MqttConnectionSettings(hostname)
+        {
+            ClientId = clientId,
+            CertFile = certFile,
+            KeyFile = keyFile,
+            Username = username,
+            Password = "",
+            KeepAliveInSeconds =  Default_KeepAliveInSeconds,
+            CleanSession = cleanSession,
+            TcpPort = tcpPort,
+            UseTls = useTLS,
+            CaFile = "",
+            DisableCrl = false,
+            KeyFilePassword = "",
+
+        };
+    }
+    
     public static MqttConnectionSettings CreateFromEnvVars(string? envFile = "")
     {
         if (string.IsNullOrEmpty(envFile))


### PR DESCRIPTION
Utilisation du KeyVault pour stocker les certificats et les secrets du .env 

Pour indiquer le nom du KeyVault, il est nécessaire de faire cette commande en local : 
```
dotnet user-secrets set "KeyVault:KeyVaultName" "<name_KeyVault>"
```